### PR TITLE
Better Cross Platform Powershell Core Support

### DIFF
--- a/Install-WorkdayModule.ps1
+++ b/Install-WorkdayModule.ps1
@@ -1,6 +1,11 @@
 ﻿[CmdletBinding()]
 param (
-    [string]$InstallPath = (Join-Path $env:ProgramFiles 'WindowsPowerShell\Modules\WorkdayApi'),
+    [string]$InstallPath = $(
+        If (($env:OS -eq 'Windows_NT') -Or ($PSVersionTable.platform -eq 'Win32NT')){
+            Join-Path $env:ProgramFiles 'WindowsPowerShell\Modules\WorkdayApi'
+        }ElseIf(($PSVersionTable.platform -eq 'Unix')){
+            Join-Path ~/.local/share/ 'powershell/Modules/WorkdayApi'
+        }),
     [switch]$Force
 )
 

--- a/WorkdayApi.psm1
+++ b/WorkdayApi.psm1
@@ -7,7 +7,13 @@ $WorkdayConfiguration = @{
     Credential = $null
 }
 
-$WorkdayConfigurationFile = Join-Path $env:LOCALAPPDATA WorkdayConfiguration.clixml
+$WorkdayConfigurationFile = $(
+    If (($env:OS -eq 'Windows_NT') -Or ($PSVersionTable.platform -eq 'Win32NT')){
+        Join-Path $env:LOCALAPPDATA WorkdayConfiguration.clixml
+    }ElseIf(($PSVersionTable.platform -eq 'Unix')){
+        Join-Path ~/.workdayapi/ 'WorkdayConfiguration.clixml'
+    })
+
 if (Test-Path $WorkdayConfigurationFile) {
     $WorkdayConfiguration = Import-Clixml $WorkdayConfigurationFile
 }


### PR DESCRIPTION
Fixes issue #3 (or at least fixes basic installation - more work may need to be done.  I'm not sure.)

I was unable to install on Powershell Core 6.0 on Ubuntu Linux because of one or two hard coded Windows defaults.  This adds some logic that should work for powershell on windows and powershell core on windows/linux.