### PR TITLE
Removed redundant Ordered accelerator

### DIFF
--- a/source/public/Invoke-WorkdayRequest.ps1
+++ b/source/public/Invoke-WorkdayRequest.ps1
@@ -98,7 +98,7 @@ At C:\Program Files\WindowsPowerShell\Modules\WorkdayApi\scripts\Invoke-WorkdayR
 	}
 
 
-     $o = [pscustomobject][ordered]@{
+     $o = [pscustomobject]@{
         Success    = $false
         Message  = 'Unknown Error'
         Xml = $null


### PR DESCRIPTION
The PSCustomObject accelerator also keeps order, so you can drop the extra ordered accelerator